### PR TITLE
Remove BitBucket requirement

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,10 +7,9 @@ if [[ $bitbucket_access =~ "^logged in as" ]]; then
 else
     echo ""
     echo "-------------------------------------------------------"
-    echo "Please fix access to bitbucket an try again."
+    echo "No access to BitBucket detected. If you don't need it, just ignore this. Otherwise fix it and try again."
     echo "Consider 'ssh-add -K' or updating your .ssh/config like described at https://nerderati.com/2011/03/17/simplify-your-life-with-an-ssh-config-file/"
     echo "-------------------------------------------------------"
-    return
 fi
 echo -n "Checking github access"
 github_access=$(ssh -T git@github.com 2>&1)


### PR DESCRIPTION
It is no longer required to have BitBucket SSH access for most developers.

This change eases the SSH check and prints a warning instead of failing.