### PR TITLE
chore: transfer ownership to squad-dark-matter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lunarway/squad-esa
+* @lunarway/squad-dark-matter

--- a/shuttle.yaml
+++ b/shuttle.yaml
@@ -1,5 +1,5 @@
 plan: false
 vars:
   service: lw-zsh-install
-  squad: esa
+  squad: dark-matter
   domain: developer-productivity


### PR DESCRIPTION
Updates CODEOWNERS and shuttle.yaml to point to squad-dark-matter.

Part of [DMAT-8](https://linear.app/lunar/issue/DMAT-8).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates ownership metadata (`CODEOWNERS`) and service metadata (`shuttle.yaml`) only, with no runtime behavior changes.
> 
> **Overview**
> Transfers repository ownership to **@lunarway/squad-dark-matter** by updating `CODEOWNERS`.
> 
> Updates `shuttle.yaml` metadata to set `vars.squad` to `dark-matter` for the `lw-zsh-install` service.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1834f4d46a736b3e46b329d4972e282f5f1367e4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->